### PR TITLE
Make logo link to top of each language page

### DIFF
--- a/index-es.html
+++ b/index-es.html
@@ -31,12 +31,12 @@
         }
     </style>
 </head>
-<body class="bg-white text-gray-800">
+<body id="top" class="bg-white text-gray-800">
 
     <!-- Header / Nav -->
     <header class="bg-white sticky top-0 z-50 shadow-sm">
         <div class="container mx-auto px-6 py-4 flex justify-between items-center">
-            <div class="text-2xl font-bold text-indigo-600">Automate<span class="text-gray-700">Wise</span></div>
+            <a href="index-es.html#top" class="text-2xl font-bold text-indigo-600">Automate<span class="text-gray-700">Wise</span></a>
             <nav class="hidden md:flex space-x-8">
                 <a href="#services" class="text-gray-600 hover:text-indigo-600">Servicios</a>
                 <a href="#connectors" class="text-gray-600 hover:text-indigo-600">Conectores</a>

--- a/index-fr.html
+++ b/index-fr.html
@@ -31,12 +31,12 @@
         }
     </style>
 </head>
-<body class="bg-white text-gray-800">
+<body id="top" class="bg-white text-gray-800">
 
     <!-- Header / Nav -->
     <header class="bg-white sticky top-0 z-50 shadow-sm">
         <div class="container mx-auto px-6 py-4 flex justify-between items-center">
-            <div class="text-2xl font-bold text-indigo-600">Automate<span class="text-gray-700">Wise</span></div>
+            <a href="index-fr.html#top" class="text-2xl font-bold text-indigo-600">Automate<span class="text-gray-700">Wise</span></a>
             <nav class="hidden md:flex space-x-8">
                 <a href="#services" class="text-gray-600 hover:text-indigo-600">Services</a>
                 <a href="#connectors" class="text-gray-600 hover:text-indigo-600">Connecteurs</a>

--- a/index.html
+++ b/index.html
@@ -31,12 +31,12 @@
         }
     </style>
 </head>
-<body class="bg-white text-gray-800">
+<body id="top" class="bg-white text-gray-800">
 
     <!-- Header / Nav -->
     <header class="bg-white sticky top-0 z-50 shadow-sm">
         <div class="container mx-auto px-6 py-4 flex justify-between items-center">
-            <div class="text-2xl font-bold text-indigo-600">Automate<span class="text-gray-700">Wise</span></div>
+            <a href="index.html#top" class="text-2xl font-bold text-indigo-600">Automate<span class="text-gray-700">Wise</span></a>
             <nav class="hidden md:flex space-x-8">
                 <a href="#services" class="text-gray-600 hover:text-indigo-600">Services</a>
                 <a href="#connectors" class="text-gray-600 hover:text-indigo-600">Connectors</a>


### PR DESCRIPTION
## Summary
- Link AutomateWise logo to top of landing page in English, French, and Spanish versions
- Add top anchor to page bodies for scroll-to-top behavior

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62a73fdfc832690d027d59413f163