### PR TITLE
Use AutomateWise logomark as favicon

### DIFF
--- a/index-es.html
+++ b/index-es.html
@@ -6,6 +6,7 @@
     <title>Servicios de consultoría en automatización IA</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="automatewise-logomark.svg">
     <style>
         body {
             font-family: 'Inter', sans-serif;

--- a/index-fr.html
+++ b/index-fr.html
@@ -6,6 +6,7 @@
     <title>Services de conseil en automatisation IA</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="automatewise-logomark.svg">
     <style>
         body {
             font-family: 'Inter', sans-serif;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>AI Automation Consulting Services</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="automatewise-logomark.svg">
     <style>
         body {
             font-family: 'Inter', sans-serif;


### PR DESCRIPTION
## Summary
- add AutomateWise logomark SVG as the website favicon
- apply favicon to English, French, and Spanish landing pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62c65f62483269d8d6ccae0ef2dbd